### PR TITLE
fix: handle error and stop loading on login page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -79,6 +79,8 @@ const LoginPage = () => {
       setLoading(false);
       router.push("/dashboard");
     } catch (error: any) {
+      setLoading(false);
+      console.error(error)
       // message.error((error as Error).message)
       return;
     }


### PR DESCRIPTION
Suspect an error thrown by [getKeyFromLocalStorage ](https://github.com/smarterwallet/wallet-ui/blob/dev/src/app/login/page.tsx#L52), disable loading and print the error message